### PR TITLE
Add previous variable snippet

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -73,4 +73,23 @@
     "prev state": {
         "prefix": "prev",
         "body": [ "const prev${1/(.*)/${1:/capitalize}/}Ref = useRef();", "useEffect(() => {", "\tprev${1/(.*)/${1:/capitalize}/}Ref.current = $1;", "});", "const prev$1 = prev${1:/capitalize}/}Ref.current;"]
+    },
+    "import react-redux hooks": {
+        "prefix": "irrh",
+        "body": ["import { useSelector, useDispatch } from 'react-redux';"]
+    },
+    "useSelector": {
+        "prefix": "uss",
+        "body": [
+            "const $1 = useSelector(state => $2);"
+        ]
+    },
+    "useDispatchFunction": {
+      "prefix": "usdf",
+      "body": ["const dispatch = useDispatch();"]
+    },
+    "useDispatch": {
+      "prefix": "usd",
+      "body": ["const $1 = $2 => dispatch($3);"]
+    }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -72,6 +72,5 @@
 },
     "prev state": {
         "prefix": "prev",
-        "body": ["const prev$1Ref = useRef();", "useEffect(() => {", "\tprev$1Ref.current = $1;", "});", "const prev$1 = prev$1Ref.current;"]
-    } 
+        "body": [ "const prev${1/(.*)/${1:/capitalize}/}Ref = useRef();", "useEffect(() => {", "\tprev${1/(.*)/${1:/capitalize}/}Ref.current = $1;", "});", "const prev$1 = prev${1:/capitalize}/}Ref.current;"]
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -69,5 +69,9 @@
 
         ],
         "description": "React useReducer() hook"
-}
+},
+    "prev state": {
+        "prefix": "prev",
+        "body": ["const prev$1Ref = useRef();", "useEffect(() => {", "\tprev$1Ref.current = $1;", "});", "const prev$1 = prev$1Ref.current;"]
+    } 
 }


### PR DESCRIPTION
Hello !

Thanks for the extension, I find it really useful. 
However, I keep finding myself in the situation where I need to use the previous state/props in order to replace some `componentWillReceiveProps` or `componentDidUpdate` with hooks. Therefore, I created a snippet for this. 
It still has some work to be done unfortunately but I didn't have the time to look into it that much. The thing that needs to be done is to make the first letter uppercase/lowercase in some places but I didn't find any way to do this yet. If you're more experienced with snippets and have any suggestions, I'd gladly make changes to this.

Thanks ! 😄 