### PR TITLE
Add useEffectEvent snippet and fix retired marketplace badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # React Hooks Snippets
 
 [![CI](https://github.com/alDuncanson/react-hooks-snippets/actions/workflows/ci.yml/badge.svg)](https://github.com/alDuncanson/react-hooks-snippets/actions/workflows/ci.yml)
-[![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/AlDuncanson.react-hooks-snippets)](https://marketplace.visualstudio.com/items?itemName=AlDuncanson.react-hooks-snippets)
-[![Installs](https://img.shields.io/visual-studio-marketplace/i/AlDuncanson.react-hooks-snippets)](https://marketplace.visualstudio.com/items?itemName=AlDuncanson.react-hooks-snippets)
+[![Visual Studio Marketplace](https://vsmarketplacebadges.dev/version/AlDuncanson.react-hooks-snippets.svg)](https://marketplace.visualstudio.com/items?itemName=AlDuncanson.react-hooks-snippets)
+[![Installs](https://vsmarketplacebadges.dev/installs-short/AlDuncanson.react-hooks-snippets.svg)](https://marketplace.visualstudio.com/items?itemName=AlDuncanson.react-hooks-snippets)
 
 VS Code snippets for React Hooks.
 
@@ -24,6 +24,7 @@ Or search "React Hooks Snippets" in the Extensions sidebar.
 | `ueh` | useEffect |
 | `uleh` | useLayoutEffect |
 | `uieh` | useInsertionEffect |
+| `ueeh` | useEffectEvent |
 | `umh` | useMemo |
 | `ucbh` | useCallback |
 | `uth` | useTransition |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "react-hooks-snippets",
 	"displayName": "React Hooks Snippets",
 	"description": "Code snippets for React Hooks",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"icon": "icon.png",
 	"publisher": "AlDuncanson",
 	"repository": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -68,6 +68,15 @@
 		],
 		"description": "React useInsertionEffect() hook"
 	},
+	"useEffectEvent": {
+		"prefix": "ueeh",
+		"body": [
+			"const ${1:onEvent} = useEffectEvent(($2) => {",
+			"\t$3",
+			"});$0"
+		],
+		"description": "React useEffectEvent() hook"
+	},
 	"useMemo": {
 		"prefix": "umh",
 		"body": [


### PR DESCRIPTION
## Changes

- **New snippet**: `ueeh` → `useEffectEvent` — the only hook from the [react.dev hooks reference](https://react.dev/reference/react/hooks) that wasn't covered (stabilized in React 19.2). Prefix follows the existing effect-hook convention (`ueh`, `uleh`, `uieh`).
- **Fixed badges**: shields.io permanently retired its `visual-studio-marketplace` badge family, which is why the version and installs badges rendered as "retired badge". Swapped both to the community-maintained [vsmarketplacebadges.dev](https://vsmarketplacebadges.dev) (verified live — currently reporting v3.0.0 / 133.58K installs). Links still point to the Marketplace listing.
- **Version bump**: 3.0.0 → 3.1.0, ready to tag after merge.

## Publishing after merge

```
git checkout master && git pull
git tag v3.1.0
git push origin v3.1.0
```

The Publish workflow fires on the tag push. Note: `VSCE_PAT` may have expired since the last release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)