### PR TITLE
Bump actions/checkout to v5 and auto-create GitHub releases on publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate snippets JSON
         run: node -e "JSON.parse(require('fs').readFileSync('snippets/snippets.json'))"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,14 +5,26 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate snippets JSON
         run: node -e "JSON.parse(require('fs').readFileSync('snippets/snippets.json'))"
 
       - name: Publish to VS Marketplace
         run: npx @vscode/vsce publish -p ${{ secrets.VSCE_PAT }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes "# React Hooks Snippets $GITHUB_REF_NAME 🚀" \
+            --generate-notes


### PR DESCRIPTION
## Changes

- **`actions/checkout@v4` → `@v5`** in both workflows — v4 targets the deprecated Node 20 runtime and was generating warnings on every run.
- **Auto-create GitHub releases**: after a successful Marketplace publish, the Publish workflow now creates a GitHub release for the tag using auto-generated notes, matching the existing release format (`# React Hooks Snippets vX.Y.Z 🚀` header + What's Changed + Full Changelog). No more manual release step — just push a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)