### PR TITLE
Release 3.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ on everything you'd want to edit. It works in JavaScript, TypeScript, and
 JSX/TSX files, and covers every current hook — including the newly stable
 `useEffectEvent` — plus the `use` API and react-dom's `useFormStatus`.
 
-![Building a search component with three snippets: ush expands to useState, udvh to useDeferredValue, and umh to useMemo](https://raw.githubusercontent.com/alDuncanson/react-hooks-snippets/50cc799c3a03d93f94c0f2608874ecc741d8e73d/assets/demo.gif)
+![Building a search component with three snippets: ush expands to useState, udvh to useDeferredValue, and umh to useMemo](https://raw.githubusercontent.com/alDuncanson/react-hooks-snippets/2586d63/assets/demo.gif)
 
 Prefixes follow one simple pattern: `u` + the hook's initials + `h`. So `ush`
 is **u**se**S**tate **h**ook, `ueh` is **u**se**E**ffect **h**ook, and `ucbh`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "react-hooks-snippets",
 	"displayName": "React Hooks Snippets",
 	"description": "Code snippets for React Hooks",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"icon": "icon.png",
 	"publisher": "AlDuncanson",
 	"repository": {


### PR DESCRIPTION
Patch release to ship the refreshed README (intro, categorized snippet tables, new badges, demo gif) to the Marketplace.

- Bump version 3.1.0 → 3.1.1
- Repoint the demo gif URL from the squashed branch commit to the master commit SHA so it doesn't depend on the PR keeping the old commit alive

After merge: tag `v3.1.1` → Publish workflow ships to the Marketplace and creates the GitHub release automatically.