### PR TITLE
Add monthly hooks watchdog

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -1,0 +1,39 @@
+name: Hooks Watchdog
+
+on:
+  schedule:
+    - cron: '0 12 1 * *' # monthly, 1st at 12:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Compare snippets against react.dev
+        id: check
+        shell: bash
+        continue-on-error: true
+        run: node scripts/check-hooks.mjs | tee report.md
+
+      - name: Open issue on drift
+        if: steps.check.outcome == 'failure'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create hooks-watchdog --color D93F0B --force \
+            --description "Opened automatically by the hooks watchdog"
+          if [ -z "$(gh issue list --repo "$GITHUB_REPOSITORY" --label hooks-watchdog --state open --json number --jq '.[0].number // empty')" ]; then
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Snippets are out of sync with the React docs" \
+              --label hooks-watchdog \
+              --body-file report.md
+          else
+            echo "Watchdog issue already open — skipping."
+          fi

--- a/scripts/check-hooks.mjs
+++ b/scripts/check-hooks.mjs
@@ -1,0 +1,48 @@
+// Compares the hooks documented on react.dev against snippets.json.
+// Prints a markdown report and exits non-zero on drift so the
+// watchdog workflow can open an issue from the output.
+import { readFileSync } from 'node:fs'
+
+const SIDEBAR_URL =
+	'https://raw.githubusercontent.com/reactjs/react.dev/main/src/sidebarReference.json'
+const HOOK_PATH = /^\/reference\/react(-dom\/hooks)?\/use($|[A-Z])/
+
+const snippets = JSON.parse(readFileSync('snippets/snippets.json', 'utf8'))
+const covered = new Set(Object.keys(snippets))
+
+const res = await fetch(SIDEBAR_URL)
+if (!res.ok) throw new Error(`Failed to fetch docs sidebar: HTTP ${res.status}`)
+
+const documented = new Set()
+const walk = (node) => {
+	if (HOOK_PATH.test(node.path ?? '')) documented.add(node.title)
+	for (const child of node.routes ?? []) walk(child)
+}
+walk(await res.json())
+
+const missing = [...documented].filter((hook) => !covered.has(hook)).sort()
+const retired = [...covered].filter((hook) => !documented.has(hook)).sort()
+
+if (missing.length === 0 && retired.length === 0) {
+	console.log(`All ${documented.size} documented hooks have snippets.`)
+	process.exit(0)
+}
+
+if (missing.length > 0) {
+	console.log('### Missing snippets\n')
+	console.log('Documented on react.dev but not in `snippets/snippets.json`:\n')
+	for (const hook of missing) {
+		console.log(`- [ ] [\`${hook}\`](https://react.dev/reference/react/${hook})`)
+	}
+	console.log()
+}
+
+if (retired.length > 0) {
+	console.log('### Possibly retired\n')
+	console.log('In `snippets/snippets.json` but no longer documented on react.dev:\n')
+	for (const hook of retired) console.log(`- [ ] \`${hook}\``)
+	console.log()
+}
+
+console.log(`_Compared against the [react.dev sidebar](${SIDEBAR_URL})._`)
+process.exit(1)


### PR DESCRIPTION
Adds a scheduled workflow that keeps the extension from silently drifting out of date — the way `useEffectEvent` did.

## How it works

- `scripts/check-hooks.mjs` fetches [`src/sidebarReference.json`](https://github.com/reactjs/react.dev/blob/main/src/sidebarReference.json) from the react.dev repo — a machine-readable nav tree — and extracts every page under `/reference/react/use*` and `/reference/react-dom/hooks/use*`.
- It diffs that set against `snippets/snippets.json` in both directions: hooks missing a snippet, and snippets for hooks no longer documented.
- On drift the workflow opens an issue with the markdown report as its body (checklist format), labeled `hooks-watchdog`. It skips creation if a watchdog issue is already open.
- Runs monthly (1st, 12:00 UTC) plus on-demand via `workflow_dispatch`.

Verified locally against the live docs: all 20 documented hooks currently have snippets, exit 0.