### PR TITLE
CI: validate snippet structure and README sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Validate snippets JSON
-        run: node -e "JSON.parse(require('fs').readFileSync('snippets/snippets.json'))"
+      - name: Validate snippets and README
+        run: node scripts/validate.mjs
 
       - name: Check extension can be packaged
         run: npx @vscode/vsce ls

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Validate snippets JSON
-        run: node -e "JSON.parse(require('fs').readFileSync('snippets/snippets.json'))"
+      - name: Validate snippets and README
+        run: node scripts/validate.mjs
 
       - name: Publish to VS Marketplace
         run: npx @vscode/vsce publish -p ${{ secrets.VSCE_PAT }}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"vscode": "^1.85.0"
 	},
 	"scripts": {
-		"lint": "node -e \"JSON.parse(require('fs').readFileSync('snippets/snippets.json'))\"",
+		"lint": "node scripts/validate.mjs",
 		"package": "vsce package",
 		"publish": "vsce publish"
 	},

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,0 +1,47 @@
+// Validates snippets.json and checks the README snippet tables stay in sync.
+import { readFileSync } from 'node:fs'
+
+const errors = []
+
+const snippets = JSON.parse(readFileSync('snippets/snippets.json', 'utf8'))
+
+const seenPrefixes = new Map()
+for (const [hook, { prefix, body, description }] of Object.entries(snippets)) {
+	if (!/^u[a-z]*h$/.test(prefix ?? '')) {
+		errors.push(`${hook}: prefix "${prefix}" doesn't follow the u…h convention`)
+	}
+	if (seenPrefixes.has(prefix)) {
+		errors.push(`${hook}: prefix "${prefix}" already used by ${seenPrefixes.get(prefix)}`)
+	}
+	seenPrefixes.set(prefix, hook)
+	if (!Array.isArray(body) || body.length === 0 || !body.every((line) => typeof line === 'string')) {
+		errors.push(`${hook}: body must be a non-empty array of strings`)
+	}
+	if (typeof description !== 'string' || description.length === 0) {
+		errors.push(`${hook}: missing description`)
+	}
+}
+
+// README table rows look like: | `ush` | [`useState`](https://…) | … |
+const readme = readFileSync('README.md', 'utf8')
+const rows = [...readme.matchAll(/^\|\s*`([^`]+)`\s*\|\s*\[`([^`]+)`\]/gm)]
+const readmePrefixByHook = new Map(rows.map((row) => [row[2], row[1]]))
+
+for (const [hook, { prefix }] of Object.entries(snippets)) {
+	const readmePrefix = readmePrefixByHook.get(hook)
+	if (readmePrefix === undefined) {
+		errors.push(`README: no table row for ${hook}`)
+	} else if (readmePrefix !== prefix) {
+		errors.push(`README: ${hook} row shows \`${readmePrefix}\` but the snippet prefix is \`${prefix}\``)
+	}
+}
+for (const hook of readmePrefixByHook.keys()) {
+	if (!(hook in snippets)) errors.push(`README: table row for ${hook} has no matching snippet`)
+}
+
+if (errors.length > 0) {
+	console.error(`${errors.length} problem(s) found:`)
+	for (const error of errors) console.error(`  - ${error}`)
+	process.exit(1)
+}
+console.log(`${Object.keys(snippets).length} snippets valid; README tables in sync.`)


### PR DESCRIPTION
Replaces the bare `JSON.parse` check with `scripts/validate.mjs`, which verifies:

- every prefix is unique and follows the `u…h` convention
- every snippet has a well-formed body (non-empty array of strings) and a description
- the README snippet tables match `snippets.json` **in both directions** — no missing rows, no orphan rows, no prefix mismatches

This turns the README's per-hook tables from a second place to forget into something CI guards. Wired into `ci.yml`, `publish.yml`, and `npm run lint`.

Tested: passes on current files; seeding a duplicate prefix, a convention violation, and README mismatches produces four precise errors and exit 1.