### PR TITLE
Publish to Open VSX

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Publish to VS Marketplace
         run: npx @vscode/vsce publish -p ${{ secrets.VSCE_PAT }}
 
+      - name: Publish to Open VSX
+        run: |
+          # create-namespace is one-time; it fails harmlessly once the namespace exists
+          npx ovsx create-namespace AlDuncanson -p ${{ secrets.OVSX_PAT }} || true
+          npx ovsx publish -p ${{ secrets.OVSX_PAT }}
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Adds an Open VSX publish step after the Marketplace publish, using the `OVSX_PAT` secret (already added to the repo).

The `AlDuncanson` namespace doesn't exist on open-vsx.org yet, so the step runs `ovsx create-namespace` first — it succeeds once, then fails harmlessly (`|| true`) on every later run.

This reaches VSCodium, Gitpod, Theia, and other editors that can't use the Microsoft marketplace. Note: this PR and #42 both touch `publish.yml` in different spots — merge order doesn't matter, GitHub will auto-resolve.