### PR TITLE
Release 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the React Hooks Snippets extension.
 
+## [3.1.2] — 2026-08-16
+
+- Now published to [Open VSX](https://open-vsx.org/) for VSCodium, Gitpod,
+  and other non-Microsoft editors
+- Added this changelog
+- Maintenance automation: a monthly watchdog opens an issue if the snippets
+  drift from the hooks documented on react.dev, and CI now validates snippet
+  structure and README consistency
+
 ## [3.1.1] — 2026-08-16
 
 - Refreshed README: intro, snippet tables grouped by react.dev category with

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "react-hooks-snippets",
 	"displayName": "React Hooks Snippets",
 	"description": "Code snippets for React Hooks",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"icon": "icon.png",
 	"publisher": "AlDuncanson",
 	"repository": {


### PR DESCRIPTION
Version bump and changelog entry for the first release with Open VSX publishing, the changelog, and the maintenance automation (hooks watchdog + strengthened CI). No snippet changes.

After merge: tag `v3.1.2` → publish workflow ships to both registries and creates the GitHub release.