### PR TITLE
Fix publish step order and vsix packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,12 +20,6 @@ jobs:
       - name: Publish to VS Marketplace
         run: npx @vscode/vsce publish -p ${{ secrets.VSCE_PAT }}
 
-      - name: Publish to Open VSX
-        run: |
-          # create-namespace is one-time; it fails harmlessly once the namespace exists
-          npx ovsx create-namespace AlDuncanson -p ${{ secrets.OVSX_PAT }} || true
-          npx ovsx publish -p ${{ secrets.OVSX_PAT }}
-
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -34,3 +28,12 @@ jobs:
             --title "$GITHUB_REF_NAME" \
             --notes "# React Hooks Snippets $GITHUB_REF_NAME 🚀" \
             --generate-notes
+
+      # Last on purpose: an Open VSX failure must not block the release.
+      # Currently failing — the ID was blocklisted after an impersonation
+      # campaign; unblock is tracked with the Open VSX registry operators.
+      - name: Publish to Open VSX
+        run: |
+          # create-namespace is one-time; it fails harmlessly once the namespace exists
+          npx ovsx create-namespace AlDuncanson -p ${{ secrets.OVSX_PAT }} || true
+          npx ovsx publish -p ${{ secrets.OVSX_PAT }}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,8 @@
+.github/**
+.vscode/**
 .vscode-test/**
 .gitignore
+scripts/**
 vsc-extension-quickstart.md
 *.vsix
 assets/**


### PR DESCRIPTION
Two fixes surfaced by the v3.1.2 release:

- **Step order**: the Open VSX failure blocked GitHub release creation. Release creation now runs before the Open VSX step, so a registry failure can't skip it. Open VSX stays last and still fails loudly while the blocklist issue is unresolved.
- **Packaging**: `.vscodeignore` was letting `.github/`, `scripts/`, and `.vscode/` into the published vsix. Now excluded.