### PR TITLE
Attach packaged vsix to GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Publish to VS Marketplace
         run: npx @vscode/vsce publish -p ${{ secrets.VSCE_PAT }}
 
+      - name: Package vsix
+        run: npx @vscode/vsce package
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -27,7 +30,8 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
             --notes "# React Hooks Snippets $GITHUB_REF_NAME 🚀" \
-            --generate-notes
+            --generate-notes \
+            react-hooks-snippets-*.vsix
 
       # Last on purpose: an Open VSX failure must not block the release.
       # Currently failing — the ID was blocklisted after an impersonation


### PR DESCRIPTION
Packages the extension during the publish workflow and attaches the `.vsix` to the GitHub release it creates.

Why: manual installs (`code --install-extension`) for corporate/air-gapped users, version pinning, a verifiable CI-built artifact — and an interim install path for VSCodium/Open VSX users while the blocklist unblock (EclipseFdn/open-vsx.org#12560) is pending.

Uses the existing `GITHUB_TOKEN`; no new secrets. Verified locally that `vsce package` produces `react-hooks-snippets-<version>.vsix` (8 files, ~101 KB after the .vscodeignore trim).