### PR TITLE
Reframe as multi-editor snippet collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 [![Rating](https://vsmarketplacebadges.dev/rating-short/AlDuncanson.react-hooks-snippets.svg?color=yellow)](https://marketplace.visualstudio.com/items?itemName=AlDuncanson.react-hooks-snippets&ssr=false#review-details)
 [![GitHub stars](https://img.shields.io/github/stars/alDuncanson/react-hooks-snippets)](https://github.com/alDuncanson/react-hooks-snippets/stargazers)
 
-React Hooks Snippets is a VS Code extension with a shorthand snippet for every
-hook in the [React docs](https://react.dev/reference/react/hooks). Type a short
-prefix, press <kbd>Tab</kbd>, and get a fully formed hook call with tab stops
-on everything you'd want to edit. It works in JavaScript, TypeScript, and
-JSX/TSX files, and covers every current hook — including the newly stable
-`useEffectEvent` — plus the `use` API and react-dom's `useFormStatus`.
+React Hooks Snippets gives you a shorthand snippet for every hook in the
+[React docs](https://react.dev/reference/react/hooks) — in VS Code, VSCodium,
+and Neovim. Type a short prefix, press <kbd>Tab</kbd>, and get a fully formed
+hook call with tab stops on everything you'd want to edit. It works in
+JavaScript, TypeScript, and JSX/TSX files, and covers every current hook —
+including the newly stable `useEffectEvent` — plus the `use` API and
+react-dom's `useFormStatus`.
 
 ![Building a search component with three snippets: ush expands to useState, udvh to useDeferredValue, and umh to useMemo](https://raw.githubusercontent.com/alDuncanson/react-hooks-snippets/2586d63/assets/demo.gif)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "react-hooks-snippets",
 	"displayName": "React Hooks Snippets",
-	"description": "Code snippets for React Hooks",
+	"description": "A snippet for every React hook",
 	"version": "3.1.2",
 	"icon": "assets/icon.png",
 	"publisher": "AlDuncanson",
@@ -14,7 +14,7 @@
 		"hooks",
 		"javascript",
 		"typescript",
-		"es6",
+		"react-hooks",
 		"snippets",
 		"snippet"
 	],


### PR DESCRIPTION
Companion to the repo-metadata updates (description + topics, already applied):

- README intro: "gives you a shorthand snippet for every hook in the React docs — in VS Code, VSCodium, and Neovim" instead of "is a VS Code extension with…"
- Manifest description: "A snippet for every React hook" — the platform-neutral tagline (feeds both the VS Marketplace and, eventually, Open VSX)
- Keywords: `es6` → `react-hooks`

Marketplace-facing copy stays snippet-focused; the multi-editor story lives where multi-editor users look.