### PR TITLE
Release 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the React Hooks Snippets extension.
 
+## [3.1.3] — 2026-08-16
+
+- First release on [Open VSX](https://open-vsx.org/extension/AlDuncanson/react-hooks-snippets)
+  for VSCodium, Gitpod, and other non-Microsoft editors
+- Documented Neovim support — the snippets load directly via LuaSnip's
+  `from_vscode` loader
+- Optimized the extension package: 106 KB → 13 KB (resized and quantized the
+  icon, dropped repo files that don't belong in the package)
+- Packaged `.vsix` files are now attached to GitHub releases for manual and
+  offline installs
+- Per-editor install docs in the README
+
 ## [3.1.2] — 2026-08-16
 
 - Now published to [Open VSX](https://open-vsx.org/) for VSCodium, Gitpod,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "react-hooks-snippets",
 	"displayName": "React Hooks Snippets",
 	"description": "A snippet for every React hook",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"icon": "assets/icon.png",
 	"publisher": "AlDuncanson",
 	"repository": {


### PR DESCRIPTION
The Open VSX debut release — the blocklist entry was removed (EclipseFdn/open-vsx.org#12560 resolved) and the namespace claim approved (https://github.com/EclipseFdn/open-vsx.org/issues/12559).

Carries everything since 3.1.2: optimized icon (103 KB → 6.7 KB), 88% smaller vsix, per-editor install docs (VS Code / Open VSX editors / Neovim), multi-editor reframing, and vsix attachment to releases.