### PR TITLE
Manual Open VSX publish workflow

### DIFF
--- a/.github/workflows/publish-openvsx.yml
+++ b/.github/workflows/publish-openvsx.yml
@@ -1,0 +1,26 @@
+name: Publish to Open VSX
+
+# Manual retry for the Open VSX side of a release — publishes the
+# vsix already attached to the given GitHub release, so it can be
+# re-run without touching the VS Marketplace.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag whose vsix to publish (e.g. v3.1.3)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  openvsx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release vsix
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "${{ inputs.tag }}" --repo "$GITHUB_REPOSITORY" --pattern '*.vsix'
+
+      - name: Publish to Open VSX
+        run: npx ovsx publish *.vsix -p ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
The v3.1.3 Open VSX publish failed on server-side cache lag — the blocklist removal landed 11 minutes before our run and the registry hadn't ingested it. The main publish job can't be re-run (the Marketplace step would fail on the duplicate version), so this adds a `workflow_dispatch` workflow that downloads the vsix already attached to a given release and publishes just that to Open VSX. Bonus: it ships the exact CI-built artifact.