### PR TITLE
Release 3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the React Hooks Snippets extension.
 
+## [3.1.4] — 2026-09-02
+
+- Added explicit MIT license, support links, and editor-specific discovery
+  metadata to the extension manifest
+- Restored compatibility with VS Code 1.25 and later
+- Refreshed the README with registry-specific install counts, a
+  registry-neutral release badge, and a Spectra Assure security assessment
+- Renamed `LICENSE.txt` to `LICENSE`
+
 ## [3.1.3] — 2026-08-16
 
 - First release on [Open VSX](https://open-vsx.org/extension/AlDuncanson/react-hooks-snippets)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "react-hooks-snippets",
 	"displayName": "React Hooks Snippets",
 	"description": "A snippet for every React hook",
-	"version": "3.1.3",
+	"version": "3.1.4",
 	"license": "MIT",
 	"icon": "assets/icon.png",
 	"publisher": "AlDuncanson",


### PR DESCRIPTION
Metadata and presentation release following #53.

- declare MIT license and resource metadata
- broaden compatibility to VS Code 1.25+
- add registry-specific download and security badges
- rename the repository license file to `LICENSE`

Validated snippet consistency and packaged `AlDuncanson.react-hooks-snippets@3.1.4` successfully.